### PR TITLE
add CMR_URLS to federated collection discovery list of APIs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -93,6 +93,7 @@ jobs:
         CLIENT_CERTIFICATE_ARN: "${{ vars.CLIENT_CERTIFICATE_ARN }}"
         CLIENT_DOMAIN_NAME: "${{ vars.CLIENT_DOMAIN_NAME }}"
         STAC_API_URLS: ${{ vars.STAC_API_URLS }}
+        CMR_URLS: ${{ vars.CMR_URLS }}
       run: |
         start_time=$(date +%s)
         poetry run npx cdk deploy --all --require-approval never --outputs-file cdk-output.json


### PR DESCRIPTION
Now the environment variable `CMR_URLS` will be used to populate a list of CMR APIs.